### PR TITLE
Fix Render startup and serve HTTP

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,28 @@
-// This file serves as a placeholder entry point for Node.js hosting platforms
-// The actual functionality is handled by Supabase Edge Functions
+// Simple Node.js server for Render deployment
+// The main API functionality is handled by Supabase Edge Functions,
+// but Render requires a web service that listens on a port.
+
+const http = require('http');
+const PORT = process.env.PORT || 3000;
 
 console.log('Dr. Greg Pedro Dental Backend - Powered by Supabase');
 console.log('Deployed on Render: https://pedrobackend.onrender.com');
 
-// This helps prevent automatic shutdown on some hosts
+const server = http.createServer((req, res) => {
+  if (req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'ok' }));
+  } else {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('Dr. Greg Pedro Dental Backend');
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+
+// Periodic log to prevent automatic shutdown on some hosts
 const keepAlive = () => {
   console.log(`[${new Date().toISOString()}] Service is still running`);
   setTimeout(keepAlive, 300000); // Log every 5 minutes

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Backend for Dr. Greg Pedro's dental practice website",
   "main": "index.js",
   "scripts": {
-    "start": "supabase start",
+    "start": "node index.js",
     "dev": "supabase start",
     "build": "npm install -g supabase && supabase init --force",
     "postbuild": "supabase db push && supabase db exec -f supabase/seed/seed_data.sql",

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     env: node
     plan: free
     buildCommand: npm install && npm install -g supabase && supabase init --force
-    startCommand: supabase start
+    startCommand: node index.js
     envVars:
       - key: SUPABASE_URL
         value: https://pedrobackend.onrender.com


### PR DESCRIPTION
## Summary
- implement basic HTTP server so Render detects the service
- update start script for node-based execution
- set Render start command to use Node

## Testing
- `npm test` *(fails: Missing script)*